### PR TITLE
Fixed time skipping when using workflow client from an activity

### DIFF
--- a/src/main/java/io/temporal/internal/testservice/SelfAdvancingTimer.java
+++ b/src/main/java/io/temporal/internal/testservice/SelfAdvancingTimer.java
@@ -20,6 +20,7 @@
 package io.temporal.internal.testservice;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.function.LongSupplier;
 
 /**
@@ -51,9 +52,9 @@ interface SelfAdvancingTimer {
    * Update lock count. The same as calling lockTimeSkipping count number of times for positive
    * count and unlockTimeSkipping for negative count.
    *
-   * @param count
+   * @param updates to the locks
    */
-  void updateLocks(int count, String caller);
+  void updateLocks(List<RequestContext.TimerLockChange> updates);
 
   void getDiagnostics(StringBuilder result);
 

--- a/src/main/java/io/temporal/internal/testservice/StateMachines.java
+++ b/src/main/java/io/temporal/internal/testservice/StateMachines.java
@@ -1112,7 +1112,7 @@ class StateMachines {
       WorkflowTaskData data,
       TestWorkflowMutableStateImpl.ConsistentQuery query,
       long notUsed) {
-    ctx.lockTimer();
+    ctx.lockTimer("scheduleQueryWorkflowTask");
     StartWorkflowExecutionRequest request = data.startRequest;
     PollWorkflowTaskQueueResponse.Builder workflowTaskResponse =
         PollWorkflowTaskQueueResponse.newBuilder();
@@ -1360,7 +1360,7 @@ class StateMachines {
     ctx.onCommit(
         (historySize) -> {
           data.clear();
-          ctx.unlockTimer();
+          ctx.unlockTimer("completeQuery");
         });
   }
 
@@ -1378,7 +1378,7 @@ class StateMachines {
     if (!data.consistentQueryRequests.isEmpty()) {
       ctx.setNeedWorkflowTask(true);
     }
-    ctx.unlockTimer();
+    ctx.unlockTimer("failQueryWorkflowTask");
   }
 
   private static void failWorkflowTask(

--- a/src/main/java/io/temporal/internal/testservice/TestWorkflowStoreImpl.java
+++ b/src/main/java/io/temporal/internal/testservice/TestWorkflowStoreImpl.java
@@ -210,7 +210,7 @@ class TestWorkflowStoreImpl implements TestWorkflowStore {
       history.checkNextEventId(ctx.getInitialEventId());
       history.addAllLocked(events, ctx.currentTimeInNanoseconds());
       result = history.getNextEventIdLocked();
-      timerService.updateLocks(ctx.getTimerLocks(), "TestWorkflowStoreImpl save");
+      timerService.updateLocks(ctx.getTimerLocks());
       ctx.fireCallbacks(history.getEventsLocked().size());
     } finally {
       if (historiesEmpty && !histories.isEmpty()) {
@@ -267,7 +267,7 @@ class TestWorkflowStoreImpl implements TestWorkflowStore {
   public void applyTimersAndLocks(RequestContext ctx) {
     lock.lock();
     try {
-      timerService.updateLocks(ctx.getTimerLocks(), "TestWorkflowStoreImpl applyTimersAndLocks");
+      timerService.updateLocks(ctx.getTimerLocks());
     } finally {
       lock.unlock();
     }
@@ -460,7 +460,7 @@ class TestWorkflowStoreImpl implements TestWorkflowStore {
       lock.unlock();
     }
     // Uncomment to troubleshoot time skipping issues.
-    //    timerService.getDiagnostics(result);
+    timerService.getDiagnostics(result);
   }
 
   @Override

--- a/src/test/java/io/temporal/internal/testing/WorkflowTestingTest.java
+++ b/src/test/java/io/temporal/internal/testing/WorkflowTestingTest.java
@@ -262,11 +262,20 @@ public class WorkflowTestingTest {
     }
   }
 
+  public static class WorkflowExecutedFromActivity implements TestWorkflow {
+
+    @Override
+    public String workflow1(String input) {
+      return Workflow.getInfo().getWorkflowType() + "-" + input;
+    }
+  }
+
+  /** Tests situation when an activity executes a workflow using a workflow client. */
   @Test
-  public void testActivityThatExecuteWorkflow() {
+  public void testActivityThatExecutesWorkflow() {
     Worker worker = testEnvironment.newWorker(TASK_QUEUE);
     worker.registerWorkflowImplementationTypes(
-        TestActivityThatExecutesWorkflowImpl.class, EmptyWorkflowImpl.class);
+        TestActivityThatExecutesWorkflowImpl.class, WorkflowExecutedFromActivity.class);
     worker.registerActivitiesImplementations(
         new ActivityThatExecutesWorkflow(testEnvironment.getWorkflowClient(), TASK_QUEUE));
     testEnvironment.start();


### PR DESCRIPTION
The TestWorkflowEnvironment has an unobvious assumption that only one blocking call to a workflow stub at a time is made. 

This didn't work with the scenario when a workflow was executed from activity in a blocking manner. This PR fixes this situation.