### PR TITLE
Fixes bug where timeout exception with no heartbeat details causes an Illegal State exception

### DIFF
--- a/src/main/java/io/temporal/common/converter/EncodedValue.java
+++ b/src/main/java/io/temporal/common/converter/EncodedValue.java
@@ -42,10 +42,13 @@ public final class EncodedValue implements Value {
 
   public Optional<Payloads> toPayloads() {
     if (payloads == null) {
-      if (converter == null) {
+      if (!value.isPresent()) {
+        payloads = Optional.empty();
+      } else if (converter == null) {
         throw new IllegalStateException("converter not set");
+      } else {
+        payloads = converter.toPayloads(value.get());
       }
-      payloads = value.isPresent() ? converter.toPayloads(value.get()) : Optional.empty();
     }
     return payloads;
   }

--- a/src/test/java/io/temporal/common/converter/EncodedValueTest.java
+++ b/src/test/java/io/temporal/common/converter/EncodedValueTest.java
@@ -19,7 +19,7 @@
 
 package io.temporal.common.converter;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 import com.google.common.base.Objects;
 import com.google.common.reflect.TypeToken;
@@ -78,5 +78,12 @@ public class EncodedValueTest {
     TypeToken<List<Pair>> typeToken = new TypeToken<List<Pair>>() {};
     List<Pair> result = v2.get(List.class, typeToken.getType());
     assertEquals(list, result);
+  }
+
+  @Test
+  public void testEmptyParameter() {
+    EncodedValue v = new EncodedValue(null);
+    Optional<Payloads> payloads = v.toPayloads();
+    assertFalse(payloads.isPresent());
   }
 }


### PR DESCRIPTION
Exception encountered:

{Failure:{Message:converter not set, Source:JavaSDK,                                                                      
                                                                  StackTrace:io.temporal.common.converter.EncodedValue.toPayloads(EncodedValue.java:46)                                     
                                                                  io.temporal.failure.FailureConvert er.exceptio nToFailureNoUnwrapping(FailureConverter.java:218)                          
                                                                  io.temporal.failure.Fail ... r.run(ThreadPoolExecutor.java:628) java.base/java.lang.Thread.run(Thread. java:835) ,        
                                                                  FailureInfo:&Failure_ApplicationFailureInfo{ApplicationFailureInfo:&ApplicationFailureInfo{Type:java.lang.IllegalStateEx  
                                                                  ception,NonR etryable:false,Details:nil,},}},

Problem: A timeout exception with no heartbeat details will not have a converter set by definition. This causes an illegal state exception instead of returning an empty details.