### PR TITLE
Fixes overzealous validation logic and adds specific check for public interfaces on registration

### DIFF
--- a/src/main/java/io/temporal/internal/sync/POJOWorkflowImplMetadata.java
+++ b/src/main/java/io/temporal/internal/sync/POJOWorkflowImplMetadata.java
@@ -19,7 +19,6 @@
 
 package io.temporal.internal.sync;
 
-import java.lang.reflect.Modifier;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -88,10 +87,6 @@ class POJOWorkflowImplMetadata {
     Class<?>[] interfaces = implClass.getInterfaces();
     for (int i = 0; i < interfaces.length; i++) {
       Class<?> anInterface = interfaces[i];
-
-      if (!Modifier.isPublic(anInterface.getModifiers())) {
-        continue;
-      }
 
       POJOWorkflowInterfaceMetadata interfaceMetadata;
       if (listener) {

--- a/src/main/java/io/temporal/internal/sync/POJOWorkflowImplMetadata.java
+++ b/src/main/java/io/temporal/internal/sync/POJOWorkflowImplMetadata.java
@@ -19,6 +19,7 @@
 
 package io.temporal.internal.sync;
 
+import java.lang.reflect.Modifier;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -87,6 +88,11 @@ class POJOWorkflowImplMetadata {
     Class<?>[] interfaces = implClass.getInterfaces();
     for (int i = 0; i < interfaces.length; i++) {
       Class<?> anInterface = interfaces[i];
+
+      if (!Modifier.isPublic(anInterface.getModifiers())) {
+        continue;
+      }
+
       POJOWorkflowInterfaceMetadata interfaceMetadata;
       if (listener) {
         interfaceMetadata =
@@ -127,7 +133,7 @@ class POJOWorkflowImplMetadata {
     }
     if (byNameType.isEmpty() && !listener) {
       throw new IllegalArgumentException(
-          "Class doesn't implement any non empty interface annotated with @WorkflowInterface: "
+          "Class doesn't implement any non empty public interface annotated with @WorkflowInterface: "
               + implClass.getName());
     }
   }

--- a/src/main/java/io/temporal/internal/sync/POJOWorkflowInterfaceMetadata.java
+++ b/src/main/java/io/temporal/internal/sync/POJOWorkflowInterfaceMetadata.java
@@ -21,6 +21,7 @@ package io.temporal.internal.sync;
 
 import io.temporal.workflow.WorkflowInterface;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -118,6 +119,7 @@ class POJOWorkflowInterfaceMetadata {
         throw new IllegalArgumentException(
             "Missing required @WorkflowInterface annotation: " + anInterface);
       }
+      validatePublicModifier(anInterface);
     }
     POJOWorkflowInterfaceMetadata result = new POJOWorkflowInterfaceMetadata(anInterface, false);
     if (result.methods.isEmpty()) {
@@ -127,6 +129,13 @@ class POJOWorkflowInterfaceMetadata {
       }
     }
     return result;
+  }
+
+  private static void validatePublicModifier(Class<?> anInterface) {
+    if (!Modifier.isPublic(anInterface.getModifiers())) {
+      throw new IllegalArgumentException(
+          "Interface with @WorkflowInterface annotation must be public: " + anInterface);
+    }
   }
 
   static POJOWorkflowInterfaceMetadata newImplementationInterface(Class<?> anInterface) {
@@ -177,7 +186,11 @@ class POJOWorkflowInterfaceMetadata {
       Class<?> current, boolean rootClass, Map<EqualsByMethodName, Method> dedupeMap) {
     WorkflowInterface annotation = current.getAnnotation(WorkflowInterface.class);
 
-    // Set to dedupe the same method due to diamond inheritance
+    if (annotation != null) {
+      validatePublicModifier(current);
+    }
+
+    // Set to de-dupe the same method due to diamond inheritance
     Set<POJOWorkflowMethod> result = new HashSet<>();
     Class<?>[] interfaces = current.getInterfaces();
     for (int i = 0; i < interfaces.length; i++) {

--- a/src/main/java/io/temporal/internal/sync/POJOWorkflowMethodMetadata.java
+++ b/src/main/java/io/temporal/internal/sync/POJOWorkflowMethodMetadata.java
@@ -37,6 +37,7 @@ class POJOWorkflowMethodMetadata {
               + methodMetadata.getMethod().getName()
               + "\" is not annotated with @WorkflowMethod, @SignalMethod or @QueryMethod");
     }
+
     this.interfaceType = Objects.requireNonNull(interfaceType);
     Optional<String> nameFromAnnotation = workflowMethod.getNameFromAnnotation();
     if (workflowMethod.getType() == WorkflowMethodType.WORKFLOW) {

--- a/src/test/java/io/temporal/internal/sync/POJOWorkflowMetadataTest.java
+++ b/src/test/java/io/temporal/internal/sync/POJOWorkflowMetadataTest.java
@@ -34,12 +34,12 @@ import org.junit.Test;
 
 public class POJOWorkflowMetadataTest {
 
-  interface A {
+  public interface A {
     @SignalMethod
     void a();
   }
 
-  interface B extends A {
+  public interface B extends A {
     @QueryMethod
     String b();
 
@@ -47,7 +47,7 @@ public class POJOWorkflowMetadataTest {
   }
 
   @WorkflowInterface
-  interface C extends B, A {
+  public interface C extends B, A {
     @SignalMethod
     void c();
 
@@ -56,24 +56,24 @@ public class POJOWorkflowMetadataTest {
   }
 
   @WorkflowInterface
-  interface E extends B {
+  public interface E extends B {
     @WorkflowMethod(name = "AM_E_bb")
     void bb();
   }
 
   @WorkflowInterface
-  interface D extends C {
+  public interface D extends C {
     @SignalMethod
     void d();
   }
 
   @WorkflowInterface
-  interface F {
+  public interface F {
     @WorkflowMethod(name = "AM_C_bb")
     void f();
   }
 
-  interface DE extends D, E {}
+  public interface DE extends D, E {}
 
   static class DImpl implements D, E {
 

--- a/src/test/java/io/temporal/internal/sync/POJOWorkflowMetadataTest.java
+++ b/src/test/java/io/temporal/internal/sync/POJOWorkflowMetadataTest.java
@@ -21,6 +21,7 @@ package io.temporal.internal.sync;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import io.temporal.worker.Worker;
 import io.temporal.workflow.QueryMethod;
@@ -71,6 +72,12 @@ public class POJOWorkflowMetadataTest {
   public interface F {
     @WorkflowMethod(name = "AM_C_bb")
     void f();
+  }
+
+  @WorkflowInterface
+  interface G {
+    @WorkflowMethod
+    void g();
   }
 
   public interface DE extends D, E {}
@@ -135,8 +142,13 @@ public class POJOWorkflowMetadataTest {
     public void f() {}
   }
 
+  static class GImpl implements G {
+    @Override
+    public void g() {}
+  }
+
   @WorkflowInterface
-  interface Empty {}
+  public interface Empty {}
 
   class EmptyImpl implements Empty {
     public void foo() {}
@@ -190,8 +202,21 @@ public class POJOWorkflowMetadataTest {
   public void testDuplicatedWorkflowImplementationRegistration() {
     try {
       POJOWorkflowImplMetadata.newInstance(DEImpl.class);
+      fail("expected an illegal argument exception");
     } catch (IllegalArgumentException e) {
       assertTrue(e.getMessage(), e.getMessage().contains("bb()"));
+    }
+  }
+
+  @Test
+  public void testNonPublicInterface() {
+    try {
+      POJOWorkflowImplMetadata.newInstance(GImpl.class);
+      fail("expected an illegal argument exception");
+    } catch (IllegalArgumentException e) {
+      assertTrue(
+          e.getMessage(),
+          e.getMessage().contains("Interface with @WorkflowInterface annotation must be public"));
     }
   }
 

--- a/src/test/java/io/temporal/workflow/WorkflowTest.java
+++ b/src/test/java/io/temporal/workflow/WorkflowTest.java
@@ -565,7 +565,14 @@ public class WorkflowTest {
         "heartbeat 3");
   }
 
-  public static class TestActivityRetryWithExpiration implements TestWorkflow1 {
+  interface EmptyInterface {}
+
+  interface UnrelatedInterface {
+    void unrelatedMethod();
+  }
+
+  public static class TestActivityRetryWithExpiration
+      implements TestWorkflow1, EmptyInterface, UnrelatedInterface {
 
     @Override
     @SuppressWarnings("Finally")
@@ -593,6 +600,9 @@ public class WorkflowTest {
       }
       return "ignored";
     }
+
+    @Override
+    public void unrelatedMethod() {}
   }
 
   @Test


### PR DESCRIPTION
- Fails registration if there are Activity/Workflow interfaces which are non-public
- Does not perform validation on interfaces that would not be leveraged / used by the Temporal SDK