### PR TITLE
Support building with JDK9 and up (#176)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,6 +107,9 @@ dependencies {
     implementation group: 'com.google.protobuf', name: 'protobuf-java-util', version: '3.12.4'
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.11.2'
     implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.11.2'
+    if (!JavaVersion.current().isJava8()) {
+        implementation 'javax.annotation:javax.annotation-api:1.3.2'
+    }
 
     testImplementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
     testImplementation group: 'com.googlecode.junit-toolbox', name: 'junit-toolbox', version: '2.4'

--- a/src/main/java/io/temporal/internal/sync/WorkflowThreadContext.java
+++ b/src/main/java/io/temporal/internal/sync/WorkflowThreadContext.java
@@ -59,7 +59,7 @@ class WorkflowThreadContext {
     if (status != Status.RUNNING) {
       throw new IllegalStateException("not in RUNNING but in " + status + " state");
     }
-    yield("created", () -> true);
+    this.yield("created", () -> true);
   }
 
   public void yield(String reason, Supplier<Boolean> unblockFunction) {

--- a/src/test/java/io/temporal/workflow/WorkflowTest.java
+++ b/src/test/java/io/temporal/workflow/WorkflowTest.java
@@ -4045,7 +4045,8 @@ public class WorkflowTest {
       assertEquals(
           "details1", ((ApplicationFailure) e.getCause()).getDetails().get(0, String.class));
       assertEquals(
-          new Integer(123), ((ApplicationFailure) e.getCause()).getDetails().get(1, Integer.class));
+          Integer.valueOf(123),
+          ((ApplicationFailure) e.getCause()).getDetails().get(1, Integer.class));
       assertEquals(
           "message='simulated 3', type='foo', nonRetryable=true", e.getCause().getMessage());
     }


### PR DESCRIPTION
Uses JSR250 javax.annotation-api as an implementation dependency
instead of the default-off java.xml.ws.annotation module in JDK9 onwards.

Differentiates use of yield identifier from the JDK14 yield keyword.

Stops using Integer(int) constructors (deprecated in JDK9).