### PR TITLE
Retry options

### DIFF
--- a/src/main/java/io/temporal/common/RetryOptions.java
+++ b/src/main/java/io/temporal/common/RetryOptions.java
@@ -66,10 +66,10 @@ public final class RetryOptions {
       if (o == null) {
         return null;
       }
-      return RetryOptions.newBuilder(o).validateBuildWithDefaults();
+      return o;
     }
     if (o == null) {
-      o = RetryOptions.newBuilder().build();
+      o = RetryOptions.getDefaultInstance();
     }
     Duration initial = merge(r.initialIntervalSeconds(), o.getInitialInterval());
     RetryOptions.Builder builder = RetryOptions.newBuilder();
@@ -89,7 +89,7 @@ public final class RetryOptions {
     return builder
         .setMaximumAttempts(merge(r.maximumAttempts(), o.getMaximumAttempts(), int.class))
         .setDoNotRetry(merge(r.doNotRetry(), o.getDoNotRetry()))
-        .validateBuildWithDefaults();
+        .build();
   }
 
   /** The parameter options takes precedence. */
@@ -104,31 +104,7 @@ public final class RetryOptions {
             merge(getBackoffCoefficient(), o.getBackoffCoefficient(), double.class))
         .setMaximumAttempts(merge(getMaximumAttempts(), o.getMaximumAttempts(), int.class))
         .setDoNotRetry(merge(getDoNotRetry(), o.getDoNotRetry()))
-        .validateBuildWithDefaults();
-  }
-
-  @SafeVarargs
-  public final RetryOptions addDoNotRetry(String... doNotRetry) {
-    if (doNotRetry == null) {
-      return this;
-    }
-
-    double backoffCoefficient = getBackoffCoefficient();
-    if (backoffCoefficient == 0) {
-      backoffCoefficient = DEFAULT_BACKOFF_COEFFICIENT;
-    }
-
-    RetryOptions.Builder builder =
-        RetryOptions.newBuilder()
-            .setInitialInterval(getInitialInterval())
-            .setMaximumInterval(getMaximumInterval())
-            .setBackoffCoefficient(backoffCoefficient)
-            .setDoNotRetry(merge(doNotRetry, getDoNotRetry()));
-
-    if (getMaximumAttempts() > 0) {
-      builder.setMaximumAttempts(getMaximumAttempts());
-    }
-    return builder.validateBuildWithDefaults();
+        .build();
   }
 
   public static final class Builder {

--- a/src/main/java/io/temporal/failure/FailureConverter.java
+++ b/src/main/java/io/temporal/failure/FailureConverter.java
@@ -199,7 +199,7 @@ public class FailureConverter {
     Failure.Builder failure =
         Failure.newBuilder().setMessage(message).setSource(JAVA_SDK).setStackTrace(stackTrace);
     if (e.getCause() != null) {
-      failure.setCause(exceptionToFailure(e.getCause()));
+      failure.setCause(exceptionToFailureNoUnwrapping(e.getCause()));
     }
     if (e instanceof ApplicationFailure) {
       ApplicationFailure ae = (ApplicationFailure) e;

--- a/src/main/java/io/temporal/internal/sync/POJOActivityTaskHandler.java
+++ b/src/main/java/io/temporal/internal/sync/POJOActivityTaskHandler.java
@@ -103,7 +103,6 @@ class POJOActivityTaskHandler implements ActivityTaskHandler {
 
   private ActivityTaskHandler.Result mapToActivityFailure(
       Throwable exception, String activityId, Scope metricsScope, boolean isLocalActivity) {
-    exception = CheckedExceptionWrapper.unwrap(exception);
     if (exception instanceof ActivityCanceledException) {
       if (isLocalActivity) {
         metricsScope.counter(MetricsType.LOCAL_ACTIVITY_CANCELED_COUNTER).inc(1);
@@ -231,6 +230,7 @@ class POJOActivityTaskHandler implements ActivityTaskHandler {
         return new ActivityTaskHandler.Result(
             info.getActivityId(), request.build(), null, null, null);
       } catch (Throwable e) {
+        e = CheckedExceptionWrapper.unwrap(e);
         if (e instanceof ActivityCanceledException) {
           if (log.isInfoEnabled()) {
             log.info(
@@ -327,6 +327,7 @@ class POJOActivityTaskHandler implements ActivityTaskHandler {
         return new ActivityTaskHandler.Result(
             info.getActivityId(), request.build(), null, null, null);
       } catch (Throwable e) {
+        e = CheckedExceptionWrapper.unwrap(e);
         if (log.isWarnEnabled()) {
           log.warn(
               "Local activity failure. ActivityId="

--- a/src/main/java/io/temporal/internal/sync/SyncWorkflowContext.java
+++ b/src/main/java/io/temporal/internal/sync/SyncWorkflowContext.java
@@ -343,9 +343,8 @@ final class SyncWorkflowContext implements WorkflowOutboundCallsInterceptor {
       activityTask.setInput(input.get());
     }
     RetryOptions retryOptions = options.getRetryOptions();
-    if (retryOptions != null) {
-      activityTask.setRetryPolicy(toRetryPolicy(retryOptions));
-    }
+    activityTask.setRetryPolicy(
+        toRetryPolicy(RetryOptions.newBuilder(retryOptions).validateBuildWithDefaults()));
     Duration localRetryThreshold = options.getLocalRetryThreshold();
     if (localRetryThreshold == null) {
       localRetryThreshold = context.getWorkflowTaskTimeout().multipliedBy(6);

--- a/src/test/java/io/temporal/workflow/WorkflowTest.java
+++ b/src/test/java/io/temporal/workflow/WorkflowTest.java
@@ -5591,6 +5591,7 @@ public class WorkflowTest {
           Workflow.newUntypedLocalActivityStub(
               LocalActivityOptions.newBuilder()
                   .setScheduleToCloseTimeout(Duration.ofSeconds(5))
+                  .setRetryOptions(RetryOptions.newBuilder().setMaximumAttempts(1).build())
                   .build());
       try {
         activity.execute("Execute", Void.class, "boo");
@@ -5791,12 +5792,14 @@ public class WorkflowTest {
             TestWorkflow1.class, newWorkflowOptionsBuilder(taskQueue).build());
     String result = workflowStub.execute(taskQueue);
     assertEquals("test123123", result);
-    assertEquals(activitiesImpl.toString(), 3, activitiesImpl.invocations.size());
+    assertEquals(activitiesImpl.toString(), 5, activitiesImpl.invocations.size());
     tracer.setExpected(
         "interceptExecuteWorkflow " + UUID_REGEXP,
         "newThread workflow-method",
         "executeLocalActivity ThrowIO",
         "currentTimeMillis",
+        "local activity ThrowIO",
+        "local activity ThrowIO",
         "local activity ThrowIO",
         "executeLocalActivity Activity2",
         "currentTimeMillis",


### PR DESCRIPTION
Fix for https://github.com/temporalio/java-sdk/issues/174.

The validation and defaulting of RetryOptions are removed when scheduling activities and child workflows. The service is expected to perform validation as well as provide defaults for them.

Added validation and defaulting of RetryOptions for local activities as service is not involved in their execution.