### PR TITLE
Adding attempt to workflow info

### DIFF
--- a/src/main/java/io/temporal/internal/replay/ReplayWorkflowContext.java
+++ b/src/main/java/io/temporal/internal/replay/ReplayWorkflowContext.java
@@ -262,4 +262,6 @@ public interface ReplayWorkflowContext extends ReplayAware {
 
   /** Updates or inserts search attributes used to index workflows. */
   void upsertSearchAttributes(SearchAttributes searchAttributes);
+
+  int getAttempt();
 }

--- a/src/main/java/io/temporal/internal/replay/ReplayWorkflowContextImpl.java
+++ b/src/main/java/io/temporal/internal/replay/ReplayWorkflowContextImpl.java
@@ -339,4 +339,9 @@ final class ReplayWorkflowContextImpl implements ReplayWorkflowContext {
     workflowStateMachines.upsertSearchAttributes(searchAttributes);
     workflowContext.mergeSearchAttributes(searchAttributes);
   }
+
+  @Override
+  public int getAttempt() {
+    return workflowContext.getAttempt();
+  }
 }

--- a/src/main/java/io/temporal/internal/replay/WorkflowContext.java
+++ b/src/main/java/io/temporal/internal/replay/WorkflowContext.java
@@ -151,6 +151,10 @@ final class WorkflowContext {
         : searchAttributes.build();
   }
 
+  int getAttempt() {
+    return startedAttributes.getAttempt();
+  }
+
   public List<ContextPropagator> getContextPropagators() {
     return contextPropagators;
   }

--- a/src/main/java/io/temporal/internal/sync/DeterministicRunnerImpl.java
+++ b/src/main/java/io/temporal/internal/sync/DeterministicRunnerImpl.java
@@ -738,5 +738,10 @@ class DeterministicRunnerImpl implements DeterministicRunner {
     public void upsertSearchAttributes(SearchAttributes searchAttributes) {
       throw new UnsupportedOperationException("not implemented");
     }
+
+    @Override
+    public int getAttempt() {
+      return 1;
+    }
   }
 }

--- a/src/main/java/io/temporal/internal/sync/WorkflowInfoImpl.java
+++ b/src/main/java/io/temporal/internal/sync/WorkflowInfoImpl.java
@@ -99,4 +99,9 @@ final class WorkflowInfoImpl implements WorkflowInfo {
         ? Optional.empty()
         : Optional.of(parentWorkflowExecution.getRunId());
   }
+
+  @Override
+  public int getAttempt() {
+    return context.getAttempt();
+  }
 }

--- a/src/main/java/io/temporal/internal/testservice/StateMachines.java
+++ b/src/main/java/io/temporal/internal/testservice/StateMachines.java
@@ -818,7 +818,8 @@ class StateMachines {
             .setWorkflowExecutionTimeout(request.getWorkflowExecutionTimeout())
             .setIdentity(request.getIdentity())
             .setInput(request.getInput())
-            .setTaskQueue(request.getTaskQueue());
+            .setTaskQueue(request.getTaskQueue())
+            .setAttempt(1);
     if (data.retryState.isPresent()) {
       a.setAttempt(data.retryState.get().getAttempt());
     }

--- a/src/main/java/io/temporal/workflow/WorkflowInfo.java
+++ b/src/main/java/io/temporal/workflow/WorkflowInfo.java
@@ -52,4 +52,6 @@ public interface WorkflowInfo {
   Optional<String> getParentWorkflowId();
 
   Optional<String> getParentRunId();
+
+  int getAttempt();
 }

--- a/src/test/java/io/temporal/workflow/WorkflowTest.java
+++ b/src/test/java/io/temporal/workflow/WorkflowTest.java
@@ -4671,6 +4671,13 @@ public class WorkflowTest {
     void proc6(String a1, int a2, int a3, int a4, int a5, int a6);
   }
 
+  @WorkflowInterface
+  public interface TestGetAttemptWorkflowsFunc {
+
+    @WorkflowMethod
+    int func();
+  }
+
   public static class TestMultiargsWorkflowsImpl
       implements TestMultiargsWorkflowsFunc,
           TestMultiargsWorkflowsFunc1,
@@ -6495,6 +6502,14 @@ public class WorkflowTest {
     }
   }
 
+  public static class TestAttemptReturningWorkflowFunc implements TestGetAttemptWorkflowsFunc {
+    @Override
+    public int func() {
+      WorkflowInfo wi = Workflow.getInfo();
+      return wi.getAttempt();
+    }
+  }
+
   public static class TestMultiargsWorkflowsFuncParent implements TestMultiargsWorkflowsFunc {
     @Override
     public String func() {
@@ -6528,6 +6543,18 @@ public class WorkflowTest {
     String result = parent.func();
     String expected = String.format("%s - %s", false, workflowId);
     assertEquals(expected, result);
+  }
+
+  @Test
+  public void testGetAttemptFromWorkflowInfo() {
+    startWorkerFor(TestMultiargsWorkflowsFuncParent.class, TestAttemptReturningWorkflowFunc.class);
+    String workflowId = "testGetAttemptWorkflow";
+    WorkflowOptions workflowOptions =
+        newWorkflowOptionsBuilder(taskQueue).setWorkflowId(workflowId).build();
+    TestGetAttemptWorkflowsFunc workflow =
+        workflowClient.newWorkflowStub(TestGetAttemptWorkflowsFunc.class, workflowOptions);
+    int attempt = workflow.func();
+    assertEquals(0, attempt); // TODO should this be equal to 1?
   }
 
   public interface WorkflowBase {

--- a/src/test/java/io/temporal/workflow/WorkflowTest.java
+++ b/src/test/java/io/temporal/workflow/WorkflowTest.java
@@ -6554,7 +6554,7 @@ public class WorkflowTest {
     TestGetAttemptWorkflowsFunc workflow =
         workflowClient.newWorkflowStub(TestGetAttemptWorkflowsFunc.class, workflowOptions);
     int attempt = workflow.func();
-    assertEquals(0, attempt); // TODO should this be equal to 1?
+    assertEquals(1, attempt);
   }
 
   public interface WorkflowBase {

--- a/src/test/java/io/temporal/workflow/WorkflowTest.java
+++ b/src/test/java/io/temporal/workflow/WorkflowTest.java
@@ -3996,6 +3996,8 @@ public class WorkflowTest {
         count = new AtomicInteger();
         retryCount.put(testName, count);
       }
+      int attempt = Workflow.getInfo().getAttempt();
+      assertEquals(count.get() + 1, attempt);
       throw ApplicationFailure.newFailure("simulated " + count.incrementAndGet(), "test");
     }
   }


### PR DESCRIPTION
This change adds feature parity with Go SDK which has attempt field in the workflow info, which comes from the workflow start event attributes.