### PR TITLE
Verify that next page is not empty in the history iterator

### DIFF
--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/WorkflowHistoryIterator.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/WorkflowHistoryIterator.java
@@ -49,7 +49,7 @@ class WorkflowHistoryIterator implements Iterator<HistoryEvent> {
   private final Scope metricsScope;
   private final PollWorkflowTaskQueueResponseOrBuilder task;
   private Iterator<HistoryEvent> current;
-  private ByteString nextPageToken;
+  ByteString nextPageToken;
 
   WorkflowHistoryIterator(
       WorkflowServiceStubs service,

--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/WorkflowHistoryIterator.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/WorkflowHistoryIterator.java
@@ -34,6 +34,7 @@ import io.temporal.internal.common.RpcRetryOptions;
 import io.temporal.serviceclient.WorkflowServiceStubs;
 import java.time.Duration;
 import java.util.Iterator;
+import java.util.NoSuchElementException;
 import java.util.Objects;
 
 /** Supports iteration over history while loading new pages through calls to the service. */
@@ -66,17 +67,36 @@ class WorkflowHistoryIterator implements Iterator<HistoryEvent> {
     nextPageToken = task.getNextPageToken();
   }
 
+  // Returns true if more history events are available.
+  // Server can return page tokens that point to empty pages.
+  // We need to verify that page is valid before returning true.
+  // Otherwise next() method would throw NoSuchElementException after hasNext() returning true.
   @Override
   public boolean hasNext() {
-    return current.hasNext() || !nextPageToken.isEmpty();
+    if (current.hasNext()) {
+      return true;
+    }
+    if (nextPageToken.isEmpty()) {
+      return false;
+    }
+
+    GetWorkflowExecutionHistoryResponse response = queryWorkflowExecutionHistory();
+
+    current = response.getHistory().getEventsList().iterator();
+    nextPageToken = response.getNextPageToken();
+
+    return current.hasNext();
   }
 
   @Override
   public HistoryEvent next() {
-    if (current.hasNext()) {
+    if (hasNext()) {
       return current.next();
     }
+    throw new NoSuchElementException();
+  }
 
+  GetWorkflowExecutionHistoryResponse queryWorkflowExecutionHistory() {
     Duration passed = Duration.ofMillis(System.currentTimeMillis()).minus(paginationStart);
     Duration expiration = workflowTaskTimeout.minus(passed);
     if (expiration.isZero() || expiration.isNegative()) {
@@ -91,28 +111,22 @@ class WorkflowHistoryIterator implements Iterator<HistoryEvent> {
             .setInitialInterval(retryServiceOperationInitialInterval)
             .setMaximumInterval(retryServiceOperationMaxInterval)
             .build();
-
     GetWorkflowExecutionHistoryRequest request =
         GetWorkflowExecutionHistoryRequest.newBuilder()
             .setNamespace(namespace)
             .setExecution(task.getWorkflowExecution())
             .setNextPageToken(nextPageToken)
             .build();
-
     try {
-      GetWorkflowExecutionHistoryResponse r =
-          GrpcRetryer.retryWithResult(
-              retryOptions,
-              () ->
-                  service
-                      .blockingStub()
-                      .withOption(METRICS_TAGS_CALL_OPTIONS_KEY, metricsScope)
-                      .getWorkflowExecutionHistory(request));
-      current = r.getHistory().getEventsList().iterator();
-      nextPageToken = r.getNextPageToken();
+      return GrpcRetryer.retryWithResult(
+          retryOptions,
+          () ->
+              service
+                  .blockingStub()
+                  .withOption(METRICS_TAGS_CALL_OPTIONS_KEY, metricsScope)
+                  .getWorkflowExecutionHistory(request));
     } catch (Exception e) {
       throw new Error(e);
     }
-    return current.next();
   }
 }

--- a/temporal-sdk/src/test/java/io/temporal/internal/replay/WorkflowHistoryIteratorTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/replay/WorkflowHistoryIteratorTest.java
@@ -1,0 +1,101 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.internal.replay;
+
+import com.google.protobuf.ByteString;
+import io.temporal.api.history.v1.History;
+import io.temporal.api.workflowservice.v1.GetWorkflowExecutionHistoryResponse;
+import io.temporal.api.workflowservice.v1.PollWorkflowTaskQueueResponse;
+import io.temporal.internal.testservice.TestWorkflowService;
+import io.temporal.serviceclient.WorkflowServiceStubs;
+import io.temporal.testUtils.HistoryUtils;
+import java.nio.charset.Charset;
+import java.time.Duration;
+import java.util.NoSuchElementException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class WorkflowHistoryIteratorTest {
+
+  private TestWorkflowService testService;
+  private WorkflowServiceStubs service;
+
+  @Before
+  public void setUp() {
+    testService = new TestWorkflowService(true);
+    service = testService.newClientStub();
+  }
+
+  @After
+  public void tearDown() {
+    service.shutdownNow();
+    try {
+      service.awaitTermination(1, TimeUnit.SECONDS);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    }
+    testService.close();
+  }
+
+  /*
+     This test Scenario verifies following things:
+     1. hasNext() method makes a call to the server to retrieve workflow history when current
+     history is empty and history token is available and cached the result.
+     2. next() method reuses cached history when possible.
+     3. next() throws NoSuchElementException when neither history no history token is available.
+  */
+  @Test
+  public void verifyHasNextIsFalseWhenHistoryIsEmpty() {
+    PollWorkflowTaskQueueResponse workflowTask =
+        PollWorkflowTaskQueueResponse.newBuilder()
+            .setNextPageToken(ByteString.copyFrom("next token", Charset.defaultCharset()))
+            .build();
+
+    AtomicInteger timesCalledServer = new AtomicInteger(0);
+    WorkflowHistoryIterator iterator =
+        new WorkflowHistoryIterator(
+            service, "default", workflowTask, Duration.ofSeconds(10), null) {
+          GetWorkflowExecutionHistoryResponse queryWorkflowExecutionHistory() {
+            timesCalledServer.incrementAndGet();
+            try {
+              History history = HistoryUtils.generateWorkflowTaskWithInitialHistory().getHistory();
+              return GetWorkflowExecutionHistoryResponse.newBuilder().setHistory(history).build();
+            } catch (Exception e) {
+              throw new RuntimeException(e);
+            }
+          }
+        };
+    Assert.assertEquals(0, timesCalledServer.get());
+    Assert.assertTrue(iterator.hasNext());
+    Assert.assertEquals(1, timesCalledServer.get());
+    Assert.assertNotNull(iterator.next());
+    Assert.assertTrue(iterator.hasNext());
+    Assert.assertNotNull(iterator.next());
+    Assert.assertTrue(iterator.hasNext());
+    Assert.assertNotNull(iterator.next());
+    Assert.assertFalse(iterator.hasNext());
+    Assert.assertThrows(NoSuchElementException.class, iterator::next);
+    Assert.assertEquals(1, timesCalledServer.get());
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/internal/replay/WorkflowHistoryIteratorTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/replay/WorkflowHistoryIteratorTest.java
@@ -43,7 +43,8 @@ public class WorkflowHistoryIteratorTest {
      1. hasNext() method makes a call to the server to retrieve workflow history when current
      history is empty and history token is available and cached the result.
      2. next() method reuses cached history when possible.
-     3. next() throws NoSuchElementException when neither history no history token is available.
+     3. hasNext() fetches an empty page and return false.
+     4. next() throws NoSuchElementException when neither history no history token is available.
   */
   @Test
   public void verifyHasNextIsFalseWhenHistoryIsEmpty() {

--- a/temporal-sdk/src/test/java/io/temporal/internal/replay/WorkflowHistoryIteratorTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/internal/replay/WorkflowHistoryIteratorTest.java
@@ -23,40 +23,15 @@ import com.google.protobuf.ByteString;
 import io.temporal.api.history.v1.History;
 import io.temporal.api.workflowservice.v1.GetWorkflowExecutionHistoryResponse;
 import io.temporal.api.workflowservice.v1.PollWorkflowTaskQueueResponse;
-import io.temporal.internal.testservice.TestWorkflowService;
-import io.temporal.serviceclient.WorkflowServiceStubs;
 import io.temporal.testUtils.HistoryUtils;
 import java.nio.charset.Charset;
 import java.time.Duration;
 import java.util.NoSuchElementException;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
 public class WorkflowHistoryIteratorTest {
-
-  private TestWorkflowService testService;
-  private WorkflowServiceStubs service;
-
-  @Before
-  public void setUp() {
-    testService = new TestWorkflowService(true);
-    service = testService.newClientStub();
-  }
-
-  @After
-  public void tearDown() {
-    service.shutdownNow();
-    try {
-      service.awaitTermination(1, TimeUnit.SECONDS);
-    } catch (InterruptedException e) {
-      e.printStackTrace();
-    }
-    testService.close();
-  }
 
   /*
      This test Scenario verifies following things:
@@ -74,8 +49,7 @@ public class WorkflowHistoryIteratorTest {
 
     AtomicInteger timesCalledServer = new AtomicInteger(0);
     WorkflowHistoryIterator iterator =
-        new WorkflowHistoryIterator(
-            service, "default", workflowTask, Duration.ofSeconds(10), null) {
+        new WorkflowHistoryIterator(null, "default", workflowTask, Duration.ofSeconds(10), null) {
           GetWorkflowExecutionHistoryResponse queryWorkflowExecutionHistory() {
             timesCalledServer.incrementAndGet();
             try {


### PR DESCRIPTION
Next page token may point to an empty page. This results in a possibility that hasNext() may return true and then next() throws NoSuchElementException. This sequence is invalid and breaks iterator contract.

Here is example of an exception that we've observed:
```
Caused by: io.grpc.StatusRuntimeException: INVALID_ARGUMENT: java.util.NoSuchElementException
	at java.base/java.util.Collections$EmptyIterator.next(Collections.java:4277)
	at io.temporal.internal.replay.WorkflowHistoryIterator.next(WorkflowHistoryIterator.java:116)
	at io.temporal.internal.replay.WorkflowHistoryIterator.next(WorkflowHistoryIterator.java:40)
	at io.temporal.internal.replay.ReplayWorkflowRunTaskHandler.handleWorkflowTaskImpl(ReplayWorkflowRunTaskHandler.java:179)
	at io.temporal.internal.replay.ReplayWorkflowRunTaskHandler.handleQueryWorkflowTask(ReplayWorkflowRunTaskHandler.java:255)
	at io.temporal.internal.replay.ReplayWorkflowTaskHandler.handleQueryOnlyWorkflowTask(ReplayWorkflowTaskHandler.java:241)
	at io.temporal.internal.replay.ReplayWorkflowTaskHandler.handleWorkflowTask(ReplayWorkflowTaskHandler.java:110)
	at io.temporal.internal.worker.WorkflowWorker$TaskHandlerImpl.handle(WorkflowWorker.java:309)
	at io.temporal.internal.worker.WorkflowWorker$TaskHandlerImpl.handle(WorkflowWorker.java:275)
	at io.temporal.internal.worker.PollTaskExecutor.lambda$process$0(PollTaskExecutor.java:73)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630)
	at java.base/java.lang.Thread.run(Thread.java:832)
```

This PR addresses the problem by making a call to the server in the hasNext method and checking if the next page is not empty.