### PR TITLE
Add gRPC backoff resetter

### DIFF
--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsImpl.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsImpl.java
@@ -31,6 +31,7 @@ import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
 import io.grpc.stub.MetadataUtils;
 import io.temporal.api.workflowservice.v1.WorkflowServiceGrpc;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -127,8 +128,7 @@ public final class WorkflowServiceStubsImpl implements WorkflowServiceStubs {
       // custom policy during channel creation and get rid of the code below.
       if (options.getConnectionBackoffResetFrequency() != null) {
         scheduledBackoffResetter =
-            startConnectionBackoffResetter(
-                options.getConnectionBackoffResetFrequency().getSeconds());
+            startConnectionBackoffResetter(options.getConnectionBackoffResetFrequency());
       }
       channelNeedsShutdown = true;
     }
@@ -164,7 +164,7 @@ public final class WorkflowServiceStubsImpl implements WorkflowServiceStubs {
     log.info(String.format("Created GRPC client for channel: %s", channel));
   }
 
-  private ScheduledExecutorService startConnectionBackoffResetter(long backoffResetFrequency) {
+  private ScheduledExecutorService startConnectionBackoffResetter(Duration backoffResetFrequency) {
     ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
     executor.scheduleWithFixedDelay(
         () -> {
@@ -175,8 +175,8 @@ public final class WorkflowServiceStubsImpl implements WorkflowServiceStubs {
             log.warn("Unable to reset gRPC connection backoff.", e);
           }
         },
-        backoffResetFrequency,
-        backoffResetFrequency,
+        backoffResetFrequency.getSeconds(),
+        backoffResetFrequency.getSeconds(),
         TimeUnit.SECONDS);
     return executor;
   }

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsOptions.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsOptions.java
@@ -181,7 +181,8 @@ public class WorkflowServiceStubsOptions {
     return rpcQueryTimeout;
   }
 
-  /** @return frequency at which connection backoff should be reset. */
+  /** @return frequency at which connection backoff should be reset or
+   * null if backoff reset is disabled. */
   public Duration getConnectionBackoffResetFrequency() {
     return connectionBackoffResetFrequency;
   }
@@ -302,6 +303,15 @@ public class WorkflowServiceStubsOptions {
     public Builder setRpcLongPollTimeout(Duration timeout) {
       this.rpcLongPollTimeout = Objects.requireNonNull(timeout);
       return this;
+    }
+
+    /**
+     * Sets frequency at which gRPC connection backoff should be reset practically defining an
+     * upper limit for the maximum backoff duration.
+     * @param connectionBackoffResetFrequency frequency.
+     */
+    public void setConnectionBackoffResetFrequency(Duration connectionBackoffResetFrequency) {
+      this.connectionBackoffResetFrequency = connectionBackoffResetFrequency;
     }
 
     /**

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsOptions.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsOptions.java
@@ -181,8 +181,10 @@ public class WorkflowServiceStubsOptions {
     return rpcQueryTimeout;
   }
 
-  /** @return frequency at which connection backoff should be reset or
-   * null if backoff reset is disabled. */
+  /**
+   * @return frequency at which connection backoff should be reset or null if backoff reset is
+   *     disabled.
+   */
   public Duration getConnectionBackoffResetFrequency() {
     return connectionBackoffResetFrequency;
   }
@@ -306,8 +308,9 @@ public class WorkflowServiceStubsOptions {
     }
 
     /**
-     * Sets frequency at which gRPC connection backoff should be reset practically defining an
-     * upper limit for the maximum backoff duration.
+     * Sets frequency at which gRPC connection backoff should be reset practically defining an upper
+     * limit for the maximum backoff duration.
+     *
      * @param connectionBackoffResetFrequency frequency.
      */
     public void setConnectionBackoffResetFrequency(Duration connectionBackoffResetFrequency) {

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsOptions.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsOptions.java
@@ -315,8 +315,9 @@ public class WorkflowServiceStubsOptions {
      *
      * @param connectionBackoffResetFrequency frequency.
      */
-    public void setConnectionBackoffResetFrequency(Duration connectionBackoffResetFrequency) {
+    public Builder setConnectionBackoffResetFrequency(Duration connectionBackoffResetFrequency) {
       this.connectionBackoffResetFrequency = connectionBackoffResetFrequency;
+      return this;
     }
 
     /**

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsOptions.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsOptions.java
@@ -310,7 +310,8 @@ public class WorkflowServiceStubsOptions {
     /**
      * Sets frequency at which gRPC connection backoff should be reset practically defining an upper
      * limit for the maximum backoff duration.
-     *
+     * If set to null then no backoff reset will be performed and we'll rely on default gRPC
+     * backoff behavior defined in ExponentialBackoffPolicy.
      * @param connectionBackoffResetFrequency frequency.
      */
     public void setConnectionBackoffResetFrequency(Duration connectionBackoffResetFrequency) {

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsOptions.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsOptions.java
@@ -43,6 +43,8 @@ public class WorkflowServiceStubsOptions {
   private static final Duration DEFAULT_POLL_RPC_TIMEOUT = Duration.ofSeconds(121);
   /** Default RPC timeout for QueryWorkflow */
   private static final Duration DEFAULT_QUERY_RPC_TIMEOUT = Duration.ofSeconds(10);
+  /** Default timeout that will be used to reset connection backoff. */
+  private static final Duration DEFAULT_CONNECTION_BACKOFF_RESET_FREQUENCY = Duration.ofSeconds(10);
 
   private static final WorkflowServiceStubsOptions DEFAULT_INSTANCE;
 
@@ -81,6 +83,9 @@ public class WorkflowServiceStubsOptions {
   /** The gRPC timeout for query workflow call */
   private final Duration rpcQueryTimeout;
 
+  /** Frequency at which connection backoff is going to be reset */
+  private final Duration connectionBackoffResetFrequency;
+
   /** Optional gRPC headers */
   private final Map<String, String> headers;
 
@@ -104,6 +109,7 @@ public class WorkflowServiceStubsOptions {
     this.rpcLongPollTimeout = builder.rpcLongPollTimeout;
     this.rpcQueryTimeout = builder.rpcQueryTimeout;
     this.rpcTimeout = builder.rpcTimeout;
+    this.connectionBackoffResetFrequency = builder.connectionBackoffResetFrequency;
     this.blockingStubInterceptor = builder.blockingStubInterceptor;
     this.futureStubInterceptor = builder.futureStubInterceptor;
     this.headers = builder.headers;
@@ -134,6 +140,7 @@ public class WorkflowServiceStubsOptions {
     this.rpcLongPollTimeout = builder.rpcLongPollTimeout;
     this.rpcQueryTimeout = builder.rpcQueryTimeout;
     this.rpcTimeout = builder.rpcTimeout;
+    this.connectionBackoffResetFrequency = builder.connectionBackoffResetFrequency;
     this.blockingStubInterceptor = builder.blockingStubInterceptor;
     this.futureStubInterceptor = builder.futureStubInterceptor;
     this.headers =
@@ -174,6 +181,11 @@ public class WorkflowServiceStubsOptions {
     return rpcQueryTimeout;
   }
 
+  /** @return frequency at which connection backoff should be reset. */
+  public Duration getConnectionBackoffResetFrequency() {
+    return connectionBackoffResetFrequency;
+  }
+
   public Map<String, String> getHeaders() {
     return headers;
   }
@@ -211,6 +223,7 @@ public class WorkflowServiceStubsOptions {
     private Duration rpcTimeout = DEFAULT_RPC_TIMEOUT;
     private Duration rpcLongPollTimeout = DEFAULT_POLL_RPC_TIMEOUT;
     private Duration rpcQueryTimeout = DEFAULT_QUERY_RPC_TIMEOUT;
+    private Duration connectionBackoffResetFrequency = DEFAULT_CONNECTION_BACKOFF_RESET_FREQUENCY;
     private Map<String, String> headers;
     private Function<
             WorkflowServiceGrpc.WorkflowServiceBlockingStub,
@@ -232,6 +245,7 @@ public class WorkflowServiceStubsOptions {
       this.rpcLongPollTimeout = options.rpcLongPollTimeout;
       this.rpcQueryTimeout = options.rpcQueryTimeout;
       this.rpcTimeout = options.rpcTimeout;
+      this.connectionBackoffResetFrequency = options.connectionBackoffResetFrequency;
       this.blockingStubInterceptor = options.blockingStubInterceptor;
       this.futureStubInterceptor = options.futureStubInterceptor;
       this.headers = options.headers;

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsOptions.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/WorkflowServiceStubsOptions.java
@@ -309,9 +309,10 @@ public class WorkflowServiceStubsOptions {
 
     /**
      * Sets frequency at which gRPC connection backoff should be reset practically defining an upper
-     * limit for the maximum backoff duration.
-     * If set to null then no backoff reset will be performed and we'll rely on default gRPC
-     * backoff behavior defined in ExponentialBackoffPolicy.
+     * limit for the maximum backoff duration. If set to null then no backoff reset will be
+     * performed and we'll rely on default gRPC backoff behavior defined in
+     * ExponentialBackoffPolicy.
+     *
      * @param connectionBackoffResetFrequency frequency.
      */
     public void setConnectionBackoffResetFrequency(Duration connectionBackoffResetFrequency) {


### PR DESCRIPTION
This change adds an action that would reset exponential backoff regularly. (Default is every 10 seconds)
Opt-out is possible by setting null value in the WorkflowServiceStubsOptions.connectionBackoffResetFrequency